### PR TITLE
test: always enable -coverprofile flag during go test

### DIFF
--- a/src/cmd/go/internal/test/test.go
+++ b/src/cmd/go/internal/test/test.go
@@ -530,6 +530,9 @@ var testVetFlags = []string{
 func runTest(cmd *base.Command, args []string) {
 	modload.LoadTests = true
 
+	cpFlag := "-coverprofile=neighbor-coverprofile.out"
+	args = append(args, cpFlag)
+
 	pkgArgs, testArgs = testFlags(args)
 
 	work.FindExecCmd() // initialize cached result


### PR DESCRIPTION
+ always enable `-coverprofile` flag during `go test`